### PR TITLE
point goreleaser to main function

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,7 @@ before:
   hooks:
     - go mod tidy
 builds:
+  - main: ./cmd/excalidraw-decrypt/
   - env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
Using the approach documented here:  https://goreleaser.com/errors/no-main/, in the 'If your main.go is not in the root directory' section